### PR TITLE
Fixed saveAsRevision function expecting default model return type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 .phpunit.result.cache
+/.idea
 /vendor

--- a/src/Traits/HasRevisions.php
+++ b/src/Traits/HasRevisions.php
@@ -127,10 +127,10 @@ trait HasRevisions
      * Manually save a new revision for a model instance.
      * This method should be called manually only where and if needed.
      *
-     * @return Revision
+     * @return RevisionModelContract
      * @throws Exception
      */
-    public function saveAsRevision(): Revision
+    public function saveAsRevision(): RevisionModelContract
     {
         $this->initRevisionOptions();
 


### PR DESCRIPTION
When using this package with a custom revision model, an exception will be thrown as soon as a model using the package is saved. This is because the saveAsRevision function expects the package model as the return type, this PR fixes that.