### PR TITLE
Fixed relations with custom pivot accessors

### DIFF
--- a/src/Traits/SaveRevisionJsonRepresentation.php
+++ b/src/Traits/SaveRevisionJsonRepresentation.php
@@ -135,7 +135,8 @@ trait SaveRevisionJsonRepresentation
         ];
 
         foreach ($this->{$relation}()->get() as $index => $model) {
-            $pivot = $model->pivot;
+            $accessor = $this->{$relation}()->getPivotAccessor();
+            $pivot = $model->{$accessor};
 
             foreach ($model->getOriginal() as $field => $value) {
                 $data = $this->dataWithForeignKeys(


### PR DESCRIPTION
This PR adds support for custom pivot accessors. (See: https://laravel.com/docs/5.8/eloquent-relationships#many-to-many look for Customizing The pivot Attribute Name)