### PR TITLE
Allow for revisions to contain timestamps

### DIFF
--- a/src/Options/RevisionOptions.php
+++ b/src/Options/RevisionOptions.php
@@ -56,6 +56,13 @@ class RevisionOptions
     private $createRevisionWhenRollingBack = true;
 
     /**
+     * Flag indicating whether to include timestamps in the revision.
+     *
+     * @var bool
+     */
+    private $revisionTimestamps = false;
+
+    /**
      * Get the value of a property of this class.
      *
      * @param $name
@@ -155,6 +162,18 @@ class RevisionOptions
     public function disableRevisioningWhenRollingBack(): self
     {
         $this->createRevisionWhenRollingBack = false;
+
+        return $this;
+    }
+
+    /**
+     * Enable the revisioning of timestamps.
+     *
+     * @return $this
+     */
+    public function withTimestamps()
+    {
+        $this->revisionTimestamps = true;
 
         return $this;
     }

--- a/src/Traits/SaveRevisionJsonRepresentation.php
+++ b/src/Traits/SaveRevisionJsonRepresentation.php
@@ -49,7 +49,7 @@ trait SaveRevisionJsonRepresentation
 
         unset($data[$this->getKeyName()]);
 
-        if ($this->usesTimestamps()) {
+        if ($this->usesTimestamps() && !$this->revisionOptions->revisionTimestamps) {
             unset($data[$this->getCreatedAtColumn()]);
             unset($data[$this->getUpdatedAtColumn()]);
         }

--- a/tests/HasRevisionsTest.php
+++ b/tests/HasRevisionsTest.php
@@ -194,6 +194,25 @@ class HasRevisionsTest extends TestCase
     }
 
     /** @test */
+    public function it_can_include_timestamps_when_creating_a_revision()
+    {
+        $model = new class extends Post {
+            public function getRevisionOptions() : RevisionOptions
+            {
+                return parent::getRevisionOptions()->withTimestamps();
+            }
+        };
+
+        $this->makeModels($model);
+        $this->modifyPost();
+
+        $revision = $this->post->revisions()->first();
+
+        $this->assertArrayHasKey('created_at', $revision->metadata);
+        $this->assertArrayHasKey('updated_at', $revision->metadata);
+    }
+
+    /** @test */
     public function it_can_save_belongs_to_relations_when_creating_a_revision()
     {
         $model = new class extends Post {


### PR DESCRIPTION
By default timestamps aren't stored in revisions, this PR adds an option to do so.